### PR TITLE
fix light plus theme and mention nodjs version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 POC App to get vscode themes working in Monaco
 
+This requires nodejs v10.
+
 
 ## Procedure to Reproduce
 

--- a/src/components/CodeEditor.js
+++ b/src/components/CodeEditor.js
@@ -59,6 +59,8 @@ const CodeEditor = ({ themes, setThemes, selectedTheme, setThemeData, setThemesC
 
   // initialize all themes. Ideally move this out but I want to keep it simple for now.
   useEffect(() => {
+    const lightTheme = { ...convertTheme(lightPlusTheme), inherit: true };
+    lightTheme.base = 'vs';
     setThemes([
       // working!
       { 
@@ -67,11 +69,11 @@ const CodeEditor = ({ themes, setThemes, selectedTheme, setThemeData, setThemesC
         theme: { ...convertTheme(darkPlusTheme), inherit: true, }
       },
       // not working
-      // { 
-      //   id: Themes.LIGHT_PLUS.value,
-      //   name: Themes.LIGHT_PLUS.display,
-      //   theme: { ...convertTheme(lightPlusTheme), inherit: true }
-      // },
+      { 
+        id: Themes.LIGHT_PLUS.value,
+        name: Themes.LIGHT_PLUS.display,
+        theme: lightTheme
+      },
       // not working
       // {
       //   id: Themes.CHB.value,


### PR DESCRIPTION
Hi, thanks a lot for the example.

This pull request fixes the 'light+' theme.
It also adds a mention to the required nodejs version (v10), just to save people some headache in the future, should they look at this example.